### PR TITLE
Cache loadbalancers after successfully setting value in myriad-kv

### DIFF
--- a/lib/leader.js
+++ b/lib/leader.js
@@ -3,8 +3,11 @@
 const constants = require('./constants');
 const middleware = require('./middleware');
 
+const _ = require('lodash');
 const async = require('async');
 const request = require('request');
+
+let cached_loadbalancers;
 
 module.exports = {
 
@@ -94,14 +97,18 @@ module.exports = {
                     } else if (response.statusCode != 200) {
                         core.loggers['containership-cloud'].log('warn', `Unable to fetch loadbalancers from ContainerShip Cloud: API returned ${response.statusCode}.`);
                         return callback();
-                    } else {
+                    } else if(!cached_loadbalancers || !_.isEqual(cached_loadbalancers, response.body)) {
                         core.cluster.myriad.persistence.set('containership-cloud::loadbalancers', JSON.stringify(response.body), (err) => {
                             if (err) {
                                 core.loggers['containership-cloud'].log('warn', `Error persisting loadbalancers to myriad-kv: ${err.message}`);
+                            } else {
+                                cached_loadbalancers = response.body;
                             }
 
                             return callback();
                         });
+                    } else {
+                        return callback();
                     }
                 });
             } else {


### PR DESCRIPTION
Prevent setting the same value repeatedly by checking the cached value against current loadbalancers list

@nicktate 