### PR TITLE
Stores registry providers in myriad-kv

### DIFF
--- a/lib/follower.js
+++ b/lib/follower.js
@@ -16,24 +16,21 @@ module.exports = {
         core.cluster.legiond.join('containership-cloud.backup');
 
         // enables registry authentication
-        core.scheduler.follower.container.add_pre_pull_middleware('docker', 'authentication', function(options, fn) {
+        core.scheduler.follower.container.add_pre_pull_middleware('docker', 'authentication', function(options, pre_pull_middleware_callback) {
             options.auth = [];
 
-            let request_options = {
-                url: `${constants.environment.CLOUD_API_BASE_URL}/v2/organizations/${config.organization}/registries`,
-                method: 'GET',
-                headers: {
-                    Authorization: ['Bearer', config.api_key].join(' ')
-                },
-                json: true
-            };
-
-            request(request_options, function(err, response) {
-                let registries;
-                if(err || response.statusCode != 200) {
+            core.cluster.myriad.persistence.get(constants.myriad.REGISTRIES, (err, registries) => {
+                if(err) {
+                    core.loggers['containership-cloud'].log('error', `Error reading registries from myriad-kv: ${err.message}`);
                     registries = {};
                 } else {
-                    registries = _.groupBy(response.body, 'serveraddress');
+                    try {
+                        registries = JSON.parse(registries);
+                        registries = _.groupBy(registries, 'serveraddress');
+                    } catch(err) {
+                        core.loggers['containership-cloud'].log('error', `Error parsing registries from myriad-kv: ${err.message}`);
+                        registries = {};
+                    }
                 }
 
                 registries['registry.containership.io'] = [
@@ -94,13 +91,13 @@ module.exports = {
                                 auth: ''
                             }
                         });
+
                         return fn();
-
-                    }, fn);
+                    }, pre_pull_middleware_callback);
+                } else {
+                    options.auth.push({});
+                    return pre_pull_middleware_callback();
                 }
-
-                options.auth.push({});
-                return fn();
             });
         });
 

--- a/lib/leader.js
+++ b/lib/leader.js
@@ -8,6 +8,7 @@ const async = require('async');
 const request = require('request');
 
 let cached_loadbalancers;
+let cached_registries;
 
 module.exports = {
 
@@ -31,7 +32,7 @@ module.exports = {
             let provider = 'open_source';
 
             // overrides provider if cloud-hints plugin detected a hosting provider
-            if (attributes.tags && attributes.tags.cloud) {
+            if(attributes.tags && attributes.tags.cloud) {
                 provider = attributes.tags.cloud.provider;
             }
 
@@ -55,12 +56,12 @@ module.exports = {
                 }
             };
 
-            if (attributes.praetor.leader) {
+            if(attributes.praetor.leader) {
                 core.loggers['containership-cloud'].log('debug', 'Registering cluster with ContainerShip Cloud');
                 request(options, (err, response) => {
-                    if (err) {
+                    if(err) {
                         core.loggers['containership-cloud'].log('warn', `Unable to register cluster with ContainerShip Cloud: ${err.message}`);
-                    } else if (response.statusCode != 201) {
+                    } else if(response.statusCode !== 201) {
                         core.loggers['containership-cloud'].log('warn', `Unable to register cluster with ContainerShip Cloud: API returned ${response.statusCode}.`);
                     }
 
@@ -79,7 +80,7 @@ module.exports = {
                 return callback();
             }
 
-            if (attributes.praetor.leader) {
+            if(attributes.praetor.leader) {
                 const options = {
                     url: `${constants.environment.CLOUD_API_BASE_URL}/v2/organizations/${config.organization}/clusters/${core.cluster_id}/loadbalancers`,
                     method: 'GET',
@@ -91,15 +92,15 @@ module.exports = {
                 };
 
                 request(options, (err, response) => {
-                    if (err) {
+                    if(err) {
                         core.loggers['containership-cloud'].log('warn', `Unable to fetch loadbalancers from ContainerShip Cloud: ${err.message}`);
                         return callback();
-                    } else if (response.statusCode != 200) {
+                    } else if(response.statusCode !== 200) {
                         core.loggers['containership-cloud'].log('warn', `Unable to fetch loadbalancers from ContainerShip Cloud: API returned ${response.statusCode}.`);
                         return callback();
                     } else if(!cached_loadbalancers || !_.isEqual(cached_loadbalancers, response.body)) {
                         core.cluster.myriad.persistence.set(constants.myriad.LOADBALANCERS, JSON.stringify(response.body), (err) => {
-                            if (err) {
+                            if(err) {
                                 core.loggers['containership-cloud'].log('warn', `Error persisting loadbalancers to myriad-kv: ${err.message}`);
                             } else {
                                 cached_loadbalancers = response.body;
@@ -116,9 +117,53 @@ module.exports = {
             }
         }
 
+        function sync_registries(callback) {
+            const attributes = core.cluster.legiond.get_attributes();
+
+            if(attributes.praetor.leader) {
+                const options = {
+                    url: `${constants.environment.CLOUD_API_BASE_URL}/v2/organizations/${config.organization}/registries`,
+                    method: 'GET',
+                    timeout: 5000,
+                    headers: {
+                        Authorization: `Bearer ${config.api_key}`
+                    },
+                    json: true
+                };
+
+                request(options, (err, response) => {
+                    if(err) {
+                        core.loggers['containership-cloud'].log('warn', `Unable to fetch registries from ContainerShip Cloud: ${err.message}`);
+                        return callback();
+                    } else if(response.statusCode !== 200) {
+                        core.loggers['containership-cloud'].log('warn', `Unable to fetch registries from ContainerShip Cloud: API returned ${response.statusCode}.`);
+                        return callback();
+                    } else if(!cached_registries || !_.isEqual(cached_registries, response.body)) {
+                        core.cluster.myriad.persistence.set(constants.myriad.REGISTRIES, JSON.stringify(response.body), (err) => {
+                            if(err) {
+                                core.loggers['containership-cloud'].log('warn', `Error persisting registries to myriad-kv: ${err.message}`);
+                            } else {
+                                cached_registries = response.body;
+                            }
+
+                            return callback();
+                        });
+                    } else {
+                        return callback();
+                    }
+                });
+            } else {
+                return callback();
+            }
+        }
+
         async.forever((callback) => {
             setTimeout(() => {
-                async.parallel([ register_cluster, sync_loadbalancers ], callback);
+                async.parallel([
+                    register_cluster,
+                    sync_loadbalancers,
+                    sync_registries
+                ], callback);
             }, 15000);
         });
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,8 +3,9 @@
   "version": "0.9.2",
   "dependencies": {
     "@containership/containership.cloud.constants": {
-      "version": "1.1.0",
-      "from": "@containership/containership.cloud.constants@1.1.0"
+      "version": "1.1.1",
+      "from": "@containership/containership.cloud.constants@1.1.1",
+      "resolved": "https://registry.npmjs.org/@containership/containership.cloud.constants/-/containership.cloud.constants-1.1.1.tgz"
     },
     "acorn": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "ContainerShip Developers <developers@containership.io>",
   "license": "GPL-3.0",
   "dependencies": {
-    "@containership/containership.cloud.constants": "^1.1.0",
+    "@containership/containership.cloud.constants": "^1.1.1",
     "async": "^0.9.0",
     "aws-sdk": "^2.1.21",
     "colors": "^1.1.2",


### PR DESCRIPTION
Requests registry providers from ContainerShip Cloud, storing them locally in myriad-kv. Prevents Cloud from becoming a single point of failure when deploying private applications.

fixes #79 
cc: @nicktate 