### PR TITLE
Update cli.js

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -392,6 +392,11 @@ module.exports = {
         callback: function(options) {
             config.load();
             config.config['api-url'] = constants.environment.CLOUD_API_BASE_URL;
+            
+            if( config.config.headers === undefined ) {
+                config.config.headers = {};
+            }
+            
             config.config.headers['x-containership-cloud-cluster'] = options['cluster-id'];
             config.set(config.config);
             // eslint-disable-next-line no-console


### PR DESCRIPTION
Fixed a small error that occurred when running `cs cloud use-cluster` (see #83)


**Before:**
```
$ cs cloud use-cluster 17ae8650-abc1-2345-941c-09aaa4224b91

/root/.containership/plugins/node_modules/containership.plugin.cloud/lib/cli.js:395
            config.config.headers['x-containership-cloud-cluster'] = options['cluster-id'];
                                                                   ^

TypeError: Cannot set property 'x-containership-cloud-cluster' of undefined
    at Object.callback [as cb] (/root/.containership/plugins/node_modules/containership.plugin.cloud/lib/cli.js:395:68)
    at Object.parse (/usr/lib/node_modules/containership/node_modules/nomnom/nomnom.js:302:15)
    at Object.<anonymous> (/usr/lib/node_modules/containership/index.js:110:8)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)

```

**After:**
```
$ cs cloud use-cluster 17ae8650-abc1-2345-941c-09aaa4224b91
Successfully updated config to use cluster 17ae8650-abc1-2345-941c-09aaa4224b91
```