### PR TITLE
Move fetching snapshots to pre_pull_middleware. Create codexd volume on snapshot restore

### DIFF
--- a/lib/follower.js
+++ b/lib/follower.js
@@ -134,11 +134,12 @@ module.exports = {
         });
 
         // download snapshot from ContainerShip Cloud
-        core.scheduler.follower.container.add_pre_start_middleware('docker', 'containership-cloud', function(container_options, fn) {
+        core.scheduler.follower.container.add_pre_pull_middleware('docker', 'containership-cloud', function(container_options, fn) {
             if(_.has(container_options.env_vars, 'CSC_BACKUP_ID') && !_.isEmpty(container_options.volumes)) {
 
-                let on_error = function() {
+                let on_error = function(err) {
                     core.loggers['containership-cloud'].log('warn', 'Error downloading container snapshot');
+                    core.loggers['containership-cloud'].log('error', err.message);
                 };
 
                 if(!container_options.tags || !container_options.tags.metadata || !container_options.tags.metadata.codexd || !container_options.tags.metadata.codexd.volumes) {
@@ -155,7 +156,11 @@ module.exports = {
                     };
 
                     let extract_tar = tar.Extract({path: `${core.cluster.codexd.options.base_path}/${volume_id}`}).on('error', on_error).on('end', function() {
-                        return fn();
+                        core.cluster.codexd.create_volume({
+                            id: volume_id
+                        }, () => {
+                            return fn();
+                        });
                     });
 
                     request(options).pipe(extract_tar);


### PR DESCRIPTION
Middleware needs to be moved before codexd pre_start_middleware to ensure the volume is created. Add more verbose error logging on snapshot pull failure