### PR TITLE
lib/cli.js: fix output of organization name in `list-orgs`

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -233,7 +233,7 @@ module.exports = {
                         // eslint-disable-next-line no-console
                         console.log(sprintf('%-50s %-50s %-50s',
                             [org, config.config.headers['x-containership-cloud-organization'] == org ? '*' : ''].join(''),
-                            org_details.description,
+                            org_details.description.name,
                             org_details.owner
                         ));
                     });


### PR DESCRIPTION
Signed-off-by: Chris Dituri <csdituri@gmail.com>

---

Fixes the following...

```
~ $ cs cloud list-orgs
ID                                                 ORGANIZATION                                       OWNER                                             
12345678-0000-0000-0000-000000000000*              [object Object]                                    Chris Dituri
```