### PR TITLE
restrict github scope to solely 'user:email' to match Containership Cloud

### DIFF
--- a/lib/integrations/github.js
+++ b/lib/integrations/github.js
@@ -57,7 +57,7 @@ module.exports = {
         const self = this;
 
         const options = {
-            scopes: ['user', 'repo'],
+            scopes: ['user:email'],
             note: AUTHORIZATION_NAME,
             note_url: constants.environment.CLOUD_API_BASE_URL,
             headers: {}


### PR DESCRIPTION
fixes #140 