### PR TITLE
lodash 4.x compatibility

### DIFF
--- a/lib/providers/vagrant.js
+++ b/lib/providers/vagrant.js
@@ -140,7 +140,7 @@ module.exports = {
                 line = _.initial(line);
                 return {
                     host: _.first(line),
-                    status: _.rest(line).join(' ')
+                    status: _.tail(line).join(' ')
                 };
             });
 
@@ -209,7 +209,7 @@ module.exports = {
 
         template.push('Vagrant.configure(2) do |config|');
 
-        _.times(options.leaders, function(index) {
+        _.times(options.leaders, _.bind(function(index) {
             let vm = this.template.vm({
                 type: 'leader',
                 hostname: ['leader', index].join('-'),
@@ -217,9 +217,9 @@ module.exports = {
                 memory: 512
             });
             template.push(vm);
-        }, this);
+        }, this));
 
-        _.times(options.followers, function(index) {
+        _.times(options.followers, _.bind(function(index) {
             let vm = this.template.vm({
                 type: 'follower',
                 hostname: ['follower', index].join('-'),
@@ -227,7 +227,7 @@ module.exports = {
                 memory: 1024
             });
             template.push(vm);
-        }, this);
+        }, this));
 
         template.push('end');
 


### PR DESCRIPTION
I had several errors trying to create/manage a vagrant cluster. It seems that lodash was updated to 4.x but the vagrant provider is still using lodash 3.x interfaces.

These are the issues I found however, I am still unable to make this work due to problems elsewhere that I am still troubleshooting, but that is not apparently related to the lodash upgrade.